### PR TITLE
Better analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,15 @@
       "version": "1.0.0",
       "dependencies": {
         "asciichart": "^1.5.25",
+        "async-retry": "^1.3.3",
         "axios": "^0.21.1",
+        "cli-table": "^0.3.11",
         "discord.js": "^12.5.1",
         "image-charts": "^5.6.17",
         "inspirational-quotes": "^1.0.8",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
         "node-schedule": "^2.0.0",
-        "one-liner-joke": "^1.2.0",
         "winston": "^3.3.3"
       }
     },
@@ -69,6 +70,14 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -92,6 +101,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dependencies": {
+        "colors": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/cli-table/node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/color": {
@@ -452,14 +480,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/one-liner-joke": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/one-liner-joke/-/one-liner-joke-1.2.0.tgz",
-      "integrity": "sha512-cyqGnIRKCe25ZERjlyKtpQp4BfN+iV22nC6rLtTMkJh+w300DK+9UitFzJZfilMdFKImKQO+w/G/E1sUSYBsrw==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/one-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -489,6 +509,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/safe-buffer": {
@@ -661,6 +689,14 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "requires": {
+        "retry": "0.13.1"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -681,6 +717,21 @@
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
+      }
+    },
+    "cli-table": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "requires": {
+        "colors": "1.0.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw=="
+        }
       }
     },
     "color": {
@@ -960,11 +1011,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
-    "one-liner-joke": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/one-liner-joke/-/one-liner-joke-1.2.0.tgz",
-      "integrity": "sha512-cyqGnIRKCe25ZERjlyKtpQp4BfN+iV22nC6rLtTMkJh+w300DK+9UitFzJZfilMdFKImKQO+w/G/E1sUSYBsrw=="
-    },
     "one-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -992,6 +1038,11 @@
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
+    },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "safe-buffer": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "author": "Martin Sosic (Wasp-lang)",
   "dependencies": {
     "asciichart": "^1.5.25",
+    "async-retry": "^1.3.3",
     "axios": "^0.21.1",
+    "cli-table": "^0.3.11",
     "discord.js": "^12.5.1",
     "image-charts": "^5.6.17",
     "inspirational-quotes": "^1.0.8",

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -2,10 +2,20 @@ const axios = require('axios')
 const _ = require('lodash')
 const moment = require('moment')
 const ImageCharts = require('image-charts');
+const Table = require('cli-table')
 
 const POSTHOG_KEY = process.env.WASP_POSTHOG_KEY
 
-ourDistinctIds = [
+// Here we set moment to use ISO-8601, Europe locale.
+moment.updateLocale("en", { week: {
+  dow: 1, // First day of week is Monday
+  doy: 4  // First week of year must contain 4 January (7 + 1 - 4)
+}});
+
+// These are telemetry user ids of Wasp team members
+// from the situation when we accidentally left telemetry enabled.
+// We track them here so we can ignore these events.
+const ourDistinctIds = [
   'bf3fa7a8-1c11-4f82-9542-ec1a2d28786b',
   '53669068-7441-45eb-b11b-880ad4c9c8c2',
   '380cc449-78db-4bd9-ae29-790e892c63a9',
@@ -15,161 +25,458 @@ ourDistinctIds = [
   'dc396135-c50d-4064-9563-5813056b1cc8'
 ]
 
+// This is executed when this file is run as a script.
+if (require.main === module) {
+  fetchEventsForReportGenerator().then(events => {
+    generateTotalReport(events).then(report => {
+      console.log('\n\nTOTAL REPORT')
+      showReportInCLI(report)
+    })
 
-const generateWeeklyReport = () => generateReport(
-  moment().subtract(3, 'months').day('Sunday').endOf('day'),
-  moment.duration(1, 'weeks')
-)
+    generateDailyReport(events).then(report => {
+      console.log('\n\nDAILY REPORT')
+      showReportInCLI(report)
+    })
 
-const generateDailyReport = () => generateReport(
-  moment().subtract(14, 'days').endOf('day'),
-  moment.duration(1, 'days')
-)
+    generateWeeklyReport(events).then(report => {
+      console.log('\n\nWEEKLY REPORT')
+      showReportInCLI(report)
+    })
 
-const generateReport = async (startDate, period) => {
+    generateMonthlyReport(events).then(report => {
+      console.log('\n\nMONTHLY REPORT')
+      showReportInCLI(report)
+    })
+  })
+}
 
-  // TODO: Track how long it took to run the analysis.
-  // TODO: Optimize stuff below, I ignored performance for now since we don't yet have amount of events where it would matter.
 
-  const events = (await fetchEvents('https://app.posthog.com/api/event/?event=cli'))
-        .filter(e => !ourDistinctIds.includes(e.distinct_id) )
+async function generateDailyReport (prefetchedEvents = undefined) {
+  return generatePeriodReport(14, 'day', prefetchedEvents, false)
+}
 
-  console.log('\nNumber of CLI events so far:', events.length)
+async function generateWeeklyReport (prefetchedEvents = undefined) {
+  return generatePeriodReport(12, 'week', prefetchedEvents)
+}
 
-  const eventsByProject = _.groupBy(events, e => e.distinct_id + e.properties.project_hash)
+async function generateMonthlyReport (prefetchedEvents = undefined) {
+  return generatePeriodReport(12, 'month', prefetchedEvents)
+}
 
-  const numProjectsCreatedUntilDatetime = (datetime) => {
-    return Object.values(eventsByProject)
-      .map(events => moment.min(events.map(e => moment(e.timestamp))))
-      .filter(dt => dt.isSameOrBefore(datetime))
-      .length
-  }
 
-  const numProjectsBuiltUntilDatetime = (datetime) => {
-    return Object.values(eventsByProject)
-      .map(events => events.filter(e => e.properties.is_build))
-      .map(events => moment.min(events.map(e => moment(e.timestamp))))
-      .filter(dt => dt.isSameOrBefore(datetime))
-      .length
-  }
+// TODO: Track how long it took to run the analysis.
+// TODO: Optimize, I mostly ignored performance for now since we don't yet have amount of events where it would matter.
 
-  const numUniqueUsersInPeriod = (startTime, endTime) => {
-    return new Set(
-      events
-        .filter(e => moment(e.timestamp).isSameOrBefore(endTime) && moment(e.timestamp).isAfter(startTime))
-        .map(e => e.distinct_id)
-    ).size
-  }
+// Main function of this module.
+//
+// Generates a report that calculates usage for last numPeriod periods of size periodName,
+// where periodName should be 'day' or 'week' or 'month'.
+// Each period is a central time scope of calculation.
+//
+// You can optionally pass prefetched events, in which case you should make sure
+// they are prepared (our events removed, sorted) and that they are all events available for CLI,
+// for the whole history. You should obtain them with fetchAllCliEvents(), in that case they will
+// be all good.
+async function generatePeriodReport (numPeriods, periodName, prefetchedEvents = undefined, genCohortRetentionReport = true) {
+  const events = prefetchedEvents || await fetchEventsForReportGenerator()
 
-  const numProjectsTotal = Object.keys(eventsByProject).length
-  const numProjectsBuiltTotal = Object.values(eventsByProject).filter(events => events.some(e => e.properties.is_build)).length
-  const numUniqueUsersTotal = new Set(events.map(e => e.distinct_id)).size
-
-  const numProjectsCreatedPerPeriodCumm = []
-  const numProjectsBuiltPerPeriodCumm = []
-  const numUniqueUsersPerPeriod = []
-  const periodDuration = period
-  {
-    let periodEnd = startDate
-    while (periodEnd.isBefore(moment.now())) {
-      const numCreatedProjects = numProjectsCreatedUntilDatetime(periodEnd)
-      const numBuiltProjects = numProjectsBuiltUntilDatetime(periodEnd)
-      const numUniqueUsers = numUniqueUsersInPeriod(moment(periodEnd).subtract(periodDuration), periodEnd)
-      numProjectsCreatedPerPeriodCumm.push({ periodEnd: periodEnd.format('YY-MM-DD'), count: numCreatedProjects })
-      numProjectsBuiltPerPeriodCumm.push({ periodEnd: periodEnd.format('YY-MM-DD'), count: numBuiltProjects})
-      numUniqueUsersPerPeriod.push({ periodEnd: periodEnd.format('YY-MM-DD'), count: numUniqueUsers})
-      periodEnd.add(periodDuration)
-    }
-  }
-
-  const cummulativeToDiff = (data) => {
-    return data.slice(1).reduce(
-      ({ lastCount, newData }, { periodEnd, count }) => {
-        return { lastCount: count, newData: [...newData, { periodEnd, count: count - lastCount }] }
-      },
-      { lastCount: data[0].count, newData: [] }
-    ).newData
-  }
-
-  const numProjectsCreatedPerPeriod = cummulativeToDiff(numProjectsCreatedPerPeriodCumm)
-  const numProjectsBuiltPerPeriod = cummulativeToDiff(numProjectsBuiltPerPeriodCumm)
-
-  const chartImage = (data, title, type='line') => {
-    const chart = ImageCharts()
-          .cht(type === 'line' ? 'ls' : 'bvs') // Type: lines or vertical bars? Could also be other things.
-          .chtt(title) // Title.
-          .chd('a:' + data.map(x => x.count).join(',')) // Data.
-          .chl(data.map(x => x.count).join('|')) // Value labels on bars.
-          .chxl('0:|' + data.map(x => x.periodEnd).join('|')) // X axis labels.
-          .chxs('0,s,min45max45') // On x-axis (0), skip some labels (s) and use 45 degress angle (min45max45).
-          .chs('700x400') // Size.
-          .chg('20,20') // Solid or dotted grid lines.
-          .chma('0,50,50') // Margins.
-          .chxt('x,y') // Axes to show.
-    return chart
-  }
-  const elemFromBehind = (arr, i) => arr[arr.length - 1 - i]
-
-  const periodAsText = periodDuration.locale("en").humanize()
-  report = [
-    {
-      text: ['Number of Wasp projects created:',
-             `- During last ${periodAsText}: ` + elemFromBehind(numProjectsCreatedPerPeriod, 0).count,
-             '- Total: ' + numProjectsTotal],
-      chart: chartImage(numProjectsCreatedPerPeriod, `Num projects created (per ${periodAsText})`, 'bars')
-    },
-    {
-      text: ['Number of Wasp projects built:',
-             `- During last ${periodAsText}: ` + elemFromBehind(numProjectsBuiltPerPeriod, 0).count,
-             '- Total: ' + numProjectsBuiltTotal],
-      chart: chartImage(numProjectsBuiltPerPeriod, `Num projects built (per ${periodAsText})`, 'bars')
-    },
-    {
-      text: ['Number of unique active users:',
-             `- During last ${periodAsText}: ` + elemFromBehind(numUniqueUsersPerPeriod, 0).count,
-             '- Total: ' + numUniqueUsersTotal],
-      chart: chartImage(numUniqueUsersPerPeriod, `Num unique active users (per ${periodAsText})`, 'bars')
-    },
+  const report = [
+    ... await generateUserActivityReport(numPeriods, periodName, events),
+    ...(genCohortRetentionReport ? await generateCohortRetentionReport(numPeriods, periodName, events) : []),
+    ... await generatePeriodProjectsReport(numPeriods, periodName, events),
   ]
+  return report
+}
+
+async function generatePeriodProjectsReport (numPeriods, periodName, prefetchedEvents = undefined) {
+  const events = prefetchedEvents || await fetchEventsForReportGenerator()
+
+  const eventsByActor = organizeEventsByActor(events)
+  const userEvents = eventsByActor["user"] || []
+
+  const periods = calcLastNPeriods(numPeriods, periodName)
+
+  const userEventsByProject = groupEventsByProject(userEvents)
+
+  const calcProjectCreationTime = (allProjectEvents) => {
+    return moment.min(allProjectEvents.map(e => moment(e.timestamp)))
+  }
+
+  const projectCreationTimes = Object.values(userEventsByProject).map(events => calcProjectCreationTime(events))
+  // [num_projects_created_before_end_of_period_0, num_projects_created_before_end_of_period_1, ...]
+  const numProjectsCreatedTillPeriod =
+        periods.map(([pStart, pEnd]) => projectCreationTimes.filter(t => t.isSameOrBefore(pEnd)).length)
+
+  const calcProjectFirstBuildTime = (allProjectEvents) => {
+    const buildEvents = allProjectEvents.filter(e => e.properties.is_build)
+    return buildEvents.length == 0 ? undefined : moment.min(buildEvents.map(e => moment(e.timestamp)))
+  }
+
+  const projectFirstBuildTimes = Object.values(userEventsByProject).map(es => calcProjectFirstBuildTime(es)).filter(bt => bt)
+  // [num_projects_built_before_end_of_period_0, num_projects_built_before_end_of_period_1, ...]
+  const numProjectsBuiltTillPeriod =
+        periods.map(([pStart, pEnd]) => projectFirstBuildTimes.filter(t => t.isSameOrBefore(pEnd)).length)
+
+  const report = [
+    {
+      text: [
+        "Num projects created by period end (cumm):",
+        numProjectsCreatedTillPeriod.join(" "),
+        "Num projects built by period end (cumm):",
+        numProjectsBuiltTillPeriod.join(" ")
+      ]
+    }
+  ]
+  return report
+}
+
+async function generateUserActivityReport (numPeriods, periodName, prefetchedEvents = undefined) {
+  const events = prefetchedEvents || await fetchEventsForReportGenerator()
+
+  const eventsByActor = organizeEventsByActor(events)
+  const ciEvents = eventsByActor["ci"] || []
+  const gitpodEvents = eventsByActor["gitpod"] || []
+  const replitEvents = eventsByActor["replit"] || []
+  const userEvents = eventsByActor["user"] || []
+
+  const periods = calcLastNPeriods(numPeriods, periodName)
+
+  // Couple of statistics that cover only the last of periods.
+  const numUniqueCiUsersInLastPeriod = uniqueUserIdsInPeriod(ciEvents, elemFromBehind(periods, 0)).length
+  const numUniqueGitpodUsersInLastPeriod = uniqueUserIdsInPeriod(gitpodEvents, elemFromBehind(periods, 0)).length
+  const numUniqueReplitUsersInLastPeriod = uniqueUserIdsInPeriod(replitEvents, elemFromBehind(periods, 0)).length
+
+  const uniqueUsersPerPeriodByAge = calcUniqueUsersPerPeriodByAge(userEvents, periods)
+
+  report = [ {
+    text: [
+      'Number of unique active users:',
+      `- During last ${periodName}: `
+        + _.sum(Object.values(uniqueUsersPerPeriodByAge.series).map(s => elemFromBehind(s, 0))),
+      '  - Replit / Gitpod / CI: '
+        + (numUniqueReplitUsersInLastPeriod + ' / '
+           + numUniqueGitpodUsersInLastPeriod + ' / '
+           + numUniqueCiUsersInLastPeriod),
+    ],
+    chart: buildChartImageUrl(
+      uniqueUsersPerPeriodByAge,
+      `Num unique active users (per ${periodName})`,
+      'bars'
+    )
+  } ]
 
   return report
 }
 
-const fetchEvents = async (url) => {
+// Generates report for some general statistics that cover the whole (total) time (all of the events).
+async function generateTotalReport (prefetchedEvents = undefined) {
+  // All events, sort by time (starting with oldest), with events caused by Wasp team members filtered out.
+  const events = prefetchedEvents || await fetchEventsForReportGenerator()
+
+  const eventsByActor = organizeEventsByActor(events)
+  const ciEvents = eventsByActor["ci"] || []
+  const gitpodEvents = eventsByActor["gitpod"] || []
+  const replitEvents = eventsByActor["replit"] || []
+  const userEvents = eventsByActor["user"] || []
+
+  const userEventsByProject = groupEventsByProject(userEvents)
+
+  const numProjectsTotal = Object.keys(userEventsByProject).length
+  const numProjectsBuiltTotal = Object.values(userEventsByProject)
+        .filter(events => events.some(e => e.properties.is_build)).length
+  const numUniqueUsersTotal = new Set(userEvents.map(e => e.distinct_id)).size
+  const numUniqueReplitUsersTotal = new Set(replitEvents.map(e => e.distinct_id)).size
+  const numUniqueGitpodUsersTotal = new Set(gitpodEvents.map(e => e.distinct_id)).size
+  const numUniqueCIUsersTotal = new Set(ciEvents.map(e => e.distinct_id)).size
+
+  const report = [
+    { text: [
+      'Number of unique projects in total: ' + numProjectsTotal,
+      'Number of unique projects built in total: ' + numProjectsBuiltTotal,
+      'Number of unique users in total: ' + numUniqueUsersTotal,
+      'Number of unique Replit / Gitpod / CI users in total: ' + (
+        numUniqueReplitUsersTotal + ' / ' + numUniqueGitpodUsersTotal + ' / ' + numUniqueCIUsersTotal
+      )
+    ] }
+  ]
+  return report
+}
+
+async function generateCohortRetentionReport (numPeriods, periodName, prefetchedEvents = undefined) {
+  const periodNameShort = periodName[0]
+
+  // All events, sort by time (starting with oldest), with events caused by Wasp team members filtered out.
+  const events = prefetchedEvents || await fetchEventsForReportGenerator()
+
+  const userEvents = organizeEventsByActor(events)["user"] || []
+
+  const periods = calcLastNPeriods(numPeriods, periodName)
+
+  // [<active_users_at_period_0>, <active_users_at_period_1>, ...]
+  const activeUsersAtPeriod = periods.map(p => uniqueUserIdsInPeriod(userEvents, p))
+
+  const eventsByUser = groupEventsByUser(userEvents)
+
+  // Finds all users that have their first event in the specified period.
+  function findNewUsersForPeriod ([pStart, pEnd]) {
+    return (
+      Object.entries(eventsByUser)
+        .filter(([userId, eventsOfUser]) => {
+          const timeOfFirstEvent = moment.min(eventsOfUser.map(e => moment(e.timestamp)))
+          return timeOfFirstEvent.isSameOrBefore(pEnd) && timeOfFirstEvent.isAfter(pStart)
+        })
+        .map(([userId, eventsOfUser]) => userId)
+    )
+  }
+
+  // [
+  //   [cohort_0_after_0_periods, cohort_0_after_1_period, ...],
+  //   [cohort_1_after_0_periods, cohort_1_after_1_period, ...],
+  // ]
+  // where each value is number of users from that cohort remaining at that period.
+  const cohorts = []
+  for (let i = 0; i < periods.length; i++) {
+    const cohort = []
+    const cohortUsers = findNewUsersForPeriod(periods[i])
+    cohort.push(cohortUsers.length)
+    for (let j = i + 1; j < periods.length; j++) {
+      const users = Array.from(getIntersection(
+        new Set(cohortUsers),
+        new Set(activeUsersAtPeriod[j])
+      ))
+      cohort.push(users.length)
+    }
+    cohorts.push(cohort)
+  }
+
+  const table = new Table({
+    head: [""].concat(periods.map((p, i) => `+${i}${periodNameShort}`)),
+    colAligns: ["right", ...periods.map(p => "right")],
+    // Options below remove all the decorations and colors from the table,
+    // which makes it easier for us to print it to Discord later.
+    // If you want some nicer visuals, comment out options below (.chars and .style).
+    chars: { 'top': '' , 'top-mid': '' , 'top-left': '' , 'top-right': ''
+             , 'bottom': '' , 'bottom-mid': '' , 'bottom-left': '' , 'bottom-right': ''
+             , 'left': '' , 'left-mid': '' , 'mid': '' , 'mid-mid': ''
+             , 'right': '' , 'right-mid': '' , 'middle': ' ' },
+    style: { 'head': null }
+  });
+
+  table.push(
+    ...cohorts.map((c, i) => ({
+      [`${periodNameShort} #${i}`]: [c[0], ...(c.slice(1).map(n =>
+        c[0] == 0 ? "N/A" : `${n} (${Math.round(n / c[0] * 100)}%)`
+      ))]
+    }))
+  )
+
+  const fmt = m => m.format('DD-MM-YY')
+  const firstPeriod = periods[0]
+  const lastPeriod = elemFromBehind(periods, 0)
+  const report = [{
+    text: [
+      "```",
+      table.toString(),
+      "```",
+      `Period of ${periodNameShort}  #0: ${fmt(firstPeriod[0])} - ${fmt(firstPeriod[1])}`,
+      `Period of ${periodNameShort} #${periods.length-1}: ${fmt(lastPeriod[0])} - ${fmt(lastPeriod[1])}`
+    ]
+  }]
+  return report
+}
+
+function getIntersection(setA, setB) {
+  return new Set([...setA].filter(element => setB.has(element)))
+}
+
+async function fetchEventsForReportGenerator () {
+  const allEvents = await fetchAllCliEvents()
+  console.log('\nNumber of CLI events fetched:', allEvents.length)
+  return _.sortBy(
+    allEvents.filter(e => !ourDistinctIds.includes(e.distinct_id) ),
+    'timestamp')
+}
+
+async function fetchAllCliEvents () {
+  return fetchEvents('https://app.posthog.com/api/event/?event=cli')
+}
+
+// TODO: Make it so that we fetch events only once! And then we reuse them.
+//   Maybe we could have cache for event queries? All of these even queries with
+//   older dates -> they will never change. So can I store them in some kind of in-memory cache?
+//   Or maybe even store them on disk? In tmp files?
+//   The thing is, posthog fetches first 100 events, and the passes the next 100 and so on,
+//   so requests are always differently scoped as time goes. What we could do though is:
+//   When we fetch events, we remember the date we did the fetching for, and we store them
+//   under that date. We store them somewhere like a file or in memory.
+//   Then, the next time we are fetching events, we start from that date, and fetch only
+//   the events that older than those, and once we are done, we add them to that file and update
+//   its date to be the newest one. That way we always maintain the pretty up-to-date list of
+//   all the events, and we only need to fetch new ones.
+//   Posthog accepts time period as an argument for fetching events so this will work.
+//   What happens if we lose our "cache" though? Then we need to fetch all of them at once.
+//   That might fail because posthog can complain when we are fetching too much events at once,
+//   and what happens is that it fetches a couple batches of 100 of them and then dies.
+//   So we should be smart about that, find a way to "cache" what it downloaded before we retry it,
+//   so we don't always start from 0.
+async function fetchEvents (url) {
   console.log('Fetching: ' + url)
   const response = await axios.get(url, { headers: {
     'Authorization': 'Bearer ' + POSTHOG_KEY
   }})
   const { next, results } = response.data
-  return results.concat(next ? await fetchEvents(next) : [])
+  const restOfResults = next ? await fetchEvents(next) : []
+  return results.concat(restOfResults)
 }
 
-if (require.main === module) {
-  generateWeeklyReport().then(report => {
-    console.log('\n\nWEEKLY REPORT')
-    for (const metric of report) {
-      console.log()
+// Organize events by the actors / source: Replit, Gitpod, CI, or the normal usage ("user").
+// We are most interested in normal usage, which is why we want to do this separation,
+// but we also do some analysis on the rest of events.
+function organizeEventsByActor (events) {
+  return _.groupBy(events, e => {
+    const contextValues = e.properties.context?.split(" ").map(v => v.toLowerCase()) || []
+    if (contextValues.includes("ci")) return "ci"
+    if (contextValues.includes("gitpod")) return "gitpod"
+    if (contextValues.includes("replit")) return "replit"
+    return "user"
+  })
+}
+
+// periodName should be 'day', 'week', or 'month'.
+// This will return last numPeriods complete periods with the length of periodName.
+// Returns: [[periodStartDateTime, periodEndDateTime]].
+function calcLastNPeriods (numPeriods, periodName) {
+  const startDate = moment().subtract(numPeriods, periodName).startOf(periodName)
+  const periods = []
+  for (let i = 0; i < numPeriods; i++) {
+    periods.push([moment(startDate), moment(startDate).endOf(periodName)])
+    startDate.add(1, periodName).startOf(periodName)
+  }
+  return periods
+}
+
+// The main metric we are calculating -> for each period, number of unique users, grouped by age (of usage).
+// We return it ready for displaying via chart or table.
+// Takes list of all events, ends of all periods, and period duration.
+function calcUniqueUsersPerPeriodByAge (userEvents, periods) {
+  const uniqueUsersPerPeriodByAge = {
+    // All series have the same length, which is the length of .periodEnds.
+    series: {
+      ">30d": [], // [number]
+      "(5, 30]d": [],
+      "(1, 5]d": [],
+      "<=1d": []
+    },
+    periodEnds: [] // [string] where strings are dates formatted as YY-MM-DD.
+  }
+  for (period of periods) {
+    const ids = uniqueUserIdsInPeriod(userEvents, period)
+    const ages = ids.map(id => (calcUserAgeInDays(userEvents, id)))
+    uniqueUsersPerPeriodByAge.series["<=1d"].push(ages.filter(age => age <= 1).length)
+    uniqueUsersPerPeriodByAge.series["(1, 5]d"].push(ages.filter(age => age > 1 && age <= 5).length)
+    uniqueUsersPerPeriodByAge.series["(5, 30]d"].push(ages.filter(age => age > 5 && age <= 30).length)
+    uniqueUsersPerPeriodByAge.series[">30d"].push(ages.filter(age => age > 30).length)
+
+    uniqueUsersPerPeriodByAge.periodEnds.push(period[1].format('YY-MM-DD'))
+  }
+  return uniqueUsersPerPeriodByAge
+}
+
+// { <unique_project_id>: [<project_event>] }
+function groupEventsByProject (events) {
+  return _.groupBy(events, e => e.distinct_id + e.properties.project_hash)
+}
+
+// { <unique_user_id>: [<user_event>] }
+function groupEventsByUser (events) {
+  return _.groupBy(events, e => e.distinct_id)
+}
+
+function findUsersFirstActivity (eventsOfUser) {
+  return moment.min(eventsOfUser.map(e => moment(e.timestamp)))
+}
+
+// From given events, calculates the age of user with specified user id (distinctId),
+// where age is defined as number of days between user's first event and their last event.
+// Assumes events are sorted from oldest to newest.
+function calcUserAgeInDays (events, distinctId) {
+  const oldestEvent = _.find(events, e => e.distinct_id == distinctId)
+  const newestEvent = _.findLast(events, e => e.distinct_id == distinctId)
+  return moment(newestEvent.timestamp).diff(moment(oldestEvent.timestamp), 'days') + 1
+}
+
+async function showReportInCLI (report) {
+  for (const metric of report) {
+    console.log()
+    if (metric.text) {
       for (const textLine of metric.text) {
         console.log(textLine)
       }
+    }
+    if (metric.chart) {
       console.log('- Chart: ', metric.chart.toURL())
     }
-  })
-
-  generateDailyReport().then(report => {
-    console.log('\n\nDAILY REPORT')
-    for (const metric of report) {
-      console.log()
-      for (const textLine of metric.text) {
-        console.log(textLine)
-      }
-      console.log('- Chart: ', metric.chart.toURL())
-    }
-  })
+  }
 }
+
+// Expects data to be:
+//   data = { series: { name: [number] }, periodEnds: [string] }
+// Returns a string, URL leading to image-charts.com that contains query with exact
+// instructions how to display this chart via image.
+function buildChartImageUrl (data, title, type='line') {
+  const chart = ImageCharts()
+        .cht(type === 'line' ? 'ls' : 'bvs') // Type: lines or vertical bars? Could also be other things.
+        .chtt(title) // Title.
+        .chd('a:' + Object.values(data.series).map(s => s.join(',')).join('|')) // Data series.
+        .chl(Object.values(data.series).map(s => s.map(v => v || undefined).join('|')).join('|')) // Value labels on bars.
+        .chdl(Object.keys(data.series).join('|'))  // Legend (per series)
+        .chdlp('b')  // Position of legend. 'b' is for bottom.
+        .chxl('0:|' + data.periodEnds.join('|')) // X axis labels.
+        .chxs('0,s,min45max45') // On x-axis (0), skip some labels (s) and use 45 degress angle (min45max45).
+        .chs('700x400') // Size.
+        .chg('20,20') // Solid or dotted grid lines.
+        .chma('0,50,50') // Margins.
+        .chxt('x,y') // Axes to show.
+  return chart
+}
+
+// Takes a bunch of events that have .timestamp field and returns only those that
+// happened in the period specified via (startTime, endTime).
+function filterEventsInPeriod (es, [startTime, endTime]) {
+  return es.filter(e => moment(e.timestamp).isSameOrBefore(endTime) && moment(e.timestamp).isAfter(startTime))
+}
+
+// Based on given events, finds all unique users that were active in the given period
+// and returns their ids.
+function uniqueUserIdsInPeriod (es, period) {
+  return Array.from(new Set(filterEventsInPeriod(es, period).map(e => e.distinct_id)))
+}
+
+// zip([[1,2],[3,4,5],[6,7]]) == [[1,3,6],[2,4,7]]
+function zip (arrays) {
+  const minLength = Math.min(...arrays.map(a => a.length))
+  const result = []
+  for (let i = 0; i < minLength; i++) {
+    const values = []
+    for (let j = 0; j < arrays.length; j++) {
+      values.push(arrays[j][i])
+    }
+    result.push(values)
+  }
+  return result
+}
+
+// sum([1,2,3]) == 6
+function sum (numbers) { return numbers.reduce((s, x) => s + x, 0) }
+
+// elemFromBehind([1,2,3], 0) == 3
+function elemFromBehind (arr, i) { return arr[arr.length - 1 - i] }
 
 module.exports = {
-  generateReport,
+  fetchAllCliEvents,
+  generateTotalReport,
   generateWeeklyReport,
-  generateDailyReport
+  generateDailyReport,
+  generateMonthlyReport
 }
+


### PR DESCRIPTION
This is how it works right now:

![image](https://user-images.githubusercontent.com/1536647/214054223-cc0bf07d-e6be-4628-bd1a-7eb4d4b82c7c.png)
![image](https://user-images.githubusercontent.com/1536647/214054252-c769bb2e-3aa1-49c6-ab7b-ceb221a6c8ed.png)


![image](https://user-images.githubusercontent.com/1536647/214054356-c8fb04d0-0cf6-419f-8cd4-fafe81bf5dd0.png)
![image](https://user-images.githubusercontent.com/1536647/214054392-9a2a4c33-c013-4389-8d88-141bea54d0ea.png)

![image](https://user-images.githubusercontent.com/1536647/214054464-5804a9f5-46e1-467f-81f1-1dc9b50dc6e8.png)
![image](https://user-images.githubusercontent.com/1536647/214054500-952907d8-5224-41d5-945f-79c2e4017d48.png)

Compared to before:
1. Now charts show "age" of users, via these stacked columns.
2. I filtered out Replit / Gitpod / CI users. They are shown as numbers though.
3. I added monthly report! So now we have daily, weekly, monthly. Monthly will also be generated automatically.
4. I made generation of reports in Discord less flaky (Posthog API can be flaky if we ask for too many stuff at once -> now we have retries in place which make this more robust + we ask for less data.)
5. I added cohort retention tables.
6. I removed Project charts (projects created and projects built through time), but we do show the raw numbers.

Some things we might yet want to add while at it, but I will let @matijaSos say what is needed:
1. Projects created and projects built charts. So for every type of report (weekly, monthly, daily), we could also add those charts. We had them before but I removed them now because I thought maybe they are not very important, but if they are, I will add them back. We do have raw numbers.
7. Right now we group users by their "age" (how long have they been using Wasp). But we could also group them by activity -> how many days so far have they used Wasp. Should we also generate those charts? We should discuss this, figure out what else, if anything, do we want to show.
