### PR TITLE
Bump memory to 2GB

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,4 +13,4 @@ source = "wasp_bot_storage"
 [[vm]]
 cpu_kind = 'shared'
 cpus = 1
-memory = '1gb'
+memory = '2gb'


### PR DESCRIPTION
We had issues that the Wasp Bot crashes with this error:
> [236733.182170] Out of memory: Killed process 668 (node) total-vm:12528108kB, anon-rss:815132kB, file-rss:128kB, shmem-rss:0kB, UID:1001 pgtables:15336kB oom_score_adj:0

I've increased the RAM from 1GB to 2GB