### PR TITLE
Bumps RAM size to 4GB

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,4 +13,4 @@ source = "wasp_bot_storage"
 [[vm]]
 cpu_kind = 'shared'
 cpus = 1
-memory = '2gb'
+memory = '4gb'


### PR DESCRIPTION
We had some OOM exceptions with the bot when its loading the analysis dataset in memory. We'll probably need to tackle the root cause, but for now we decided to throw more resources at the problem.